### PR TITLE
(ci) Add lint and build workflows, update dependency management

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  [push, pull_request]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,21 @@
+name: golangci-lint
+on:
+  [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11
+          

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Determine tag name
         run: |
           VERSION=$(echo $GITHUB_REF | sed -e 's,.*/\(.*\),\1,')
@@ -26,23 +26,23 @@ jobs:
           # Use lowercase name of repository, as buildx rejects the name otherwise.
           echo "repository=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: ghcr.io/${{ env.repository }}:${{ env.tag_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 Votes-Server
+VotesServer

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR /opt/wiilink/evc/Votes-Server/
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
-RUN go get github.com/WiiLink24/nwc24
 
 # Copy necessary parts of the Mail-Go source into builder's source
 COPY *.go ./

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 )
 
 require (
+	github.com/WiiLink24/nwc24 v0.0.0-20251223184323-cc2586e6b86d // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.11.0 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/RiiConnect24/wiino v0.0.0-20210419165641-a2614cecbcca h1:bqvl4vwPEGdpC//xahkhDpVTwe1ym6wTWv6EdiRxxXY=
 github.com/RiiConnect24/wiino v0.0.0-20210419165641-a2614cecbcca/go.mod h1:BmIQ5QOpoum6rxYqqAjdpwwdfoQeKVi1xnxeEU+56ro=
+github.com/WiiLink24/nwc24 v0.0.0-20251223184323-cc2586e6b86d h1:2tvROnFl0C6Y31nchMiDCx9kfHjWB9zugwkcEm2y6QE=
+github.com/WiiLink24/nwc24 v0.0.0-20251223184323-cc2586e6b86d/go.mod h1:FxcUTrS85gzEPurqt0K7Ihiy0WMIySFcxbE7mdCWk+0=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=


### PR DESCRIPTION
First, the same old changes to CI to add lint and build workflows on pushes and PRs, and also updates to the actions used in the Docker push workflow.

Additionally, this moves the dependency on `nwc24` into `go.mod`. Previously, it was only pulled in during the Docker image build and was not specified, so you would need run `go get` for it prior to building. If there is a reason that this is still necessary, I will revert it, however I don't see a reason that this is necessary right now given that nwc24 is updated very infrequently, and pinning a version is likely safer than blindly using the latest version of it every time the Docker image is built.